### PR TITLE
Fix yield multiplier calculation

### DIFF
--- a/additionalFieldInfo.lua
+++ b/additionalFieldInfo.lua
@@ -88,10 +88,10 @@ function AdditionalFieldInfo:fieldAddFarmland(data, box)
                     local fruitGrowthState = data.lastGrowthState
                     if fruitType ~= nil and farmland.field ~= nil then
                         if fruitType.growthStateToName[fruitGrowthState] == "harvestReady" then
-                            local sprayFactor = data.sprayLevel
+                            local sprayFactor = data.sprayLevel / 2
                             local plowFactor = data.plowLevel
-                            local limeFactor = 1 - data.limeLevel
-                            local weedFactor = data.weedFactor
+                            local limeFactor = data.limeLevel / 3
+                            local weedFactor = 1 - data.weedFactor
                             local stubbleFactor = data.stubbleShredLevel
                             local rollerFactor = 1 - data.rollerLevel
                             local stoneFactor = data.stoneLevel


### PR DESCRIPTION
I see you took the values from FS22 but FS25 changed some things.
I fixed it but don't know how to take into account the bee bonus, it should be +5% for Sunflowers and +2.5% for Canola and Potatoes, with a radius I’m unsure of.
And stoneLevel is useless in the calculation, it works by damaging the harvester/header and reduce yield like that but it's unpredictable.

Btw I'm not sure your FS22 it correct, I've seen people complaining it wasn't accurate.
I guess it should be like FS25 but with `data.plowLevel / 3` but I don't have FS22 to test.